### PR TITLE
Create sysstat

### DIFF
--- a/CheckList/gooroom/sysstat
+++ b/CheckList/gooroom/sysstat
@@ -1,0 +1,13 @@
+MC적용
+ 
+시스템 성능 측정을 위한 sysstat 서비스 설치 및 활성화
+
+> sysstat  설치
+# sudo apt-get install sysstat -y 
+> /etc/default/sysstat 에서  ENABLED="false"  -> "true"로 변경 
+> sysstat 실행 
+# sudo service sysstat start 
+이후 iostat, sar 등이 사용가능함 
+
+> 취약으로 변경 
+# sudo apt-get purge sysstat -y 


### PR DESCRIPTION
점검 방법
- 시스템 성능 측정을 위한 sysstat 서비스가 작동하고 있는지 조사
- check sysstat to collect accounting

원인
- 시스템 성능 측정을 위한 sysstat 서비스가 작동하고 있지 않음
- sysstat is not enabled