### PR TITLE
grub_password

### DIFF
--- a/CheckList/gooroom/grub_password
+++ b/CheckList/gooroom/grub_password
@@ -1,0 +1,17 @@
+grub-mkpasswd-pbkdf2 명령으로 암호 적용 
+
+> 패스워드 생성. 
+사용자 이름과 패스워드를 입력받아야 함.
+패스워드 두번 입력해야 함.
+패스워드로 HASH 생성 
+
+> 수정 
+입력받은 사용자 이름과 HASH값으로  /etc/grub.d/00_header 에 추가
+
+cat << EOF
+set superusers="admin"
+password_pbkdf2 admin HASH
+EOF
+
+> confirm 
+# sudo update-grub 


### PR DESCRIPTION
부팅패스워드

점검방법
- GRUB 부트로더에 암호 적용되어 있는지 조사
- check password on GRUB bootloader

원인
- GRUB 부트로더에 암호가 적용되지 않았음
- password not set on GRUB bootloader